### PR TITLE
tests: update unit tests for the upcoming changes in go sdks

### DIFF
--- a/test/payment_profiles_test.go
+++ b/test/payment_profiles_test.go
@@ -1,0 +1,66 @@
+package test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"advancedbilling/models"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type PaymentProfilesSuite struct {
+	APISuite
+}
+
+func TestPaymentProfilesSuite(t *testing.T) {
+	suite.Run(t, new(PaymentProfilesSuite))
+}
+
+func (s *PaymentProfilesSuite) TestPaymentProfiles() {
+	ctx := context.Background()
+
+	customer := s.generateCustomer(ctx)
+	pf := s.generateProductFamily(ctx)
+	product := s.generateProduct(ctx, *pf.Id)
+
+	paymentProfileRes, err := s.client.PaymentProfilesController().CreatePaymentProfile(
+		ctx,
+		&models.CreatePaymentProfileRequest{
+			PaymentProfile: models.CreatePaymentProfile{
+				CustomerId:      customer.Id,
+				ExpirationMonth: models.ToPointer(models.CreatePaymentProfileExpirationMonthContainer.FromNumber(12)),
+				ExpirationYear:  models.ToPointer(models.CreatePaymentProfileExpirationYearContainer.FromNumber(2030)),
+				FullNumber:      models.ToPointer("4111111111111111"),
+			},
+		},
+	)
+	s.NoError(err)
+	s.Equal(http.StatusCreated, paymentProfileRes.Response.StatusCode)
+
+	payCred, ok := paymentProfileRes.Data.PaymentProfile.AsCreditCardPaymentProfile()
+
+	s.Equal(true, ok)
+
+	subscriptionRes, err := s.client.SubscriptionsController().CreateSubscription(ctx, &models.CreateSubscriptionRequest{
+		Subscription: models.CreateSubscription{
+			ProductId:  product.Id,
+			CustomerId: customer.Id,
+		},
+	})
+	s.NoError(err)
+	s.Equal(http.StatusCreated, paymentProfileRes.Response.StatusCode)
+
+	paymentProfileNewRes, err := s.client.PaymentProfilesController().ChangeSubscriptionDefaultPaymentProfile(ctx, *subscriptionRes.Data.Subscription.Id, *payCred.Id)
+	s.NoError(err)
+	payCredNew, ok := paymentProfileNewRes.Data.PaymentProfile.AsCreditCardPaymentProfile()
+	s.NotNil(payCredNew)
+	s.Equal(true, ok)
+
+	paymentProfileNewNewRes, err := s.client.PaymentProfilesController().ChangeSubscriptionDefaultPaymentProfile(ctx, *subscriptionRes.Data.Subscription.Id, *payCred.Id)
+
+	s.Error(err)
+	s.NotNil(paymentProfileNewNewRes)
+	s.Equal(http.StatusUnprocessableEntity, paymentProfileRes.Response.StatusCode)
+}

--- a/test/site_test.go
+++ b/test/site_test.go
@@ -32,7 +32,7 @@ func (s *SiteSuite) TestReadSite() {
 			expectedErr: false,
 			assert: func(t *testing.T, resp models.ApiResponse[models.SiteResponse], err error) {
 				s.Equal(http.StatusOK, resp.Response.StatusCode, "status code")
-        s.NoError(err)
+				s.NoError(err)
 
 				respSite := resp.Data.Site
 				s.Equal(4718, *respSite.Id, "ID")
@@ -81,10 +81,10 @@ func (s *SiteSuite) TestReadSite() {
 			name:   "unauthorized",
 			client: s.unauthorizedClient,
 			assert: func(t *testing.T, resp models.ApiResponse[models.SiteResponse], err error) {
-			  s.Equal(err.Error(), "ApiError occured: HTTP Response Not OK. Status code: 401. Response: 'HTTP Basic: Access denied.\n'.")
+				s.Equal(err.Error(), "ApiError occured: HTTP Response Not OK. Status code: 401. Response: 'HTTP Basic: Access denied.\n'.")
 				actualErr, ok := err.(https.ApiError)
-        s.Equal(http.StatusUnauthorized, actualErr.StatusCode)
-        s.True(ok)
+				s.Equal(http.StatusUnauthorized, actualErr.StatusCode)
+				s.True(ok)
 			},
 			expectedErr: true,
 		},

--- a/test/subscription_test.go
+++ b/test/subscription_test.go
@@ -45,7 +45,7 @@ func (s *SubscriptionSuite) TestSubscriptionCreate() {
 				*coupon.Code,
 				[]models.CreateSubscriptionComponent{
 					{
-						ComponentId: interfacePtr(*component.Id),
+						ComponentId: models.ToPointer(models.CreateSubscriptionComponentComponentIdContainer.FromNumber(*component.Id)),
 						Enabled:     boolPtr(true),
 						UnitBalance: intPtr(1),
 					},
@@ -68,19 +68,9 @@ func (s *SubscriptionSuite) TestSubscriptionCreate() {
 
 				listResp, err := s.client.SubscriptionComponentsController().ListSubscriptionComponents(
 					ctx,
-					*createdSubscription.Id,
-					nil,
-					nil,
-					nil,
-					nil,
-					nil,
-					nil,
-					nil,
-					nil,
-					nil,
-					nil,
-					nil,
-					nil,
+					advancedbilling.ListSubscriptionComponentsInput{
+						SubscriptionId: *createdSubscription.Id,
+					},
 				)
 
 				s.NoError(err)
@@ -116,13 +106,13 @@ func (s *SubscriptionSuite) TestSubscriptionCreate() {
 				[]models.CreateSubscriptionComponent{},
 			),
 			assert: func(t *testing.T, ar models.ApiResponse[models.SubscriptionResponse], subscription models.CreateSubscription, err error) {
-        s.Equal(string("ErrorListResponse occured: HTTP Response Not OK. Status code: 422. Response: " +
-            "'{\"errors\":[\"Coupon Code: 'invalid coupon code' - Coupon code could not be found.\"]}'."),
-            err.Error())
+				s.Equal(string("ErrorListResponse occured: HTTP Response Not OK. Status code: 422. Response: "+
+					"'{\"errors\":[\"Coupon Code: 'invalid coupon code' - Coupon code could not be found.\"]}'."),
+					err.Error())
 
-        actualErr, ok := err.(*errors.ErrorListResponse)
-        s.Equal(http.StatusUnprocessableEntity, actualErr.StatusCode)
-        s.True(ok)
+				actualErr, ok := err.(*errors.ErrorListResponse)
+				s.Equal(http.StatusUnprocessableEntity, actualErr.StatusCode)
+				s.True(ok)
 			},
 		},
 		{
@@ -134,19 +124,19 @@ func (s *SubscriptionSuite) TestSubscriptionCreate() {
 				*coupon.Code,
 				[]models.CreateSubscriptionComponent{
 					{
-						ComponentId: interfacePtr(*component.Id),
+						ComponentId: models.ToPointer(models.CreateSubscriptionComponentComponentIdContainer.FromNumber(*component.Id)),
 						Enabled:     boolPtr(true),
 						UnitBalance: intPtr(1),
 					},
 				},
 			),
 			assert: func(t *testing.T, ar models.ApiResponse[models.SubscriptionResponse], cs models.CreateSubscription, err error) {
-        s.Equal("ApiError occured: HTTP Response Not OK. Status code: 401. Response: 'HTTP Basic: Access denied.\n'.",
-          err.Error())
+				s.Equal("ApiError occured: HTTP Response Not OK. Status code: 401. Response: 'HTTP Basic: Access denied.\n'.",
+					err.Error())
 
-        actualErr, ok := err.(https.ApiError)
-        s.Equal(http.StatusUnauthorized, actualErr.StatusCode)
-        s.True(ok)
+				actualErr, ok := err.(https.ApiError)
+				s.Equal(http.StatusUnauthorized, actualErr.StatusCode)
+				s.True(ok)
 			},
 		},
 	}
@@ -184,8 +174,8 @@ func (s *APISuite) newSubscription(
 			LastName:        &s.baseBillingAddress.lastName,
 			FullNumber:      &s.baseBillingAddress.phone,
 			CardType:        toPtr[models.CardType](models.CardType_VISA),
-			ExpirationMonth: interfacePtr(1),
-			ExpirationYear:  interfacePtr(time.Now().Year() + 1),
+			ExpirationMonth: models.ToPointer(models.PaymentProfileAttributesExpirationMonthContainer.FromNumber(1)),
+			ExpirationYear:  models.ToPointer(models.PaymentProfileAttributesExpirationYearContainer.FromNumber(time.Now().Year() + 1)),
 			BillingAddress:  &s.baseBillingAddress.address,
 			BillingCity:     &s.baseBillingAddress.city,
 			BillingState:    &s.baseBillingAddress.state,

--- a/test/suite.go
+++ b/test/suite.go
@@ -57,23 +57,23 @@ func (s *APISuite) SetupTest() {
 	}
 
 	config := advancedbilling.CreateConfiguration(
-	  advancedbilling.WithBasicAuthCredentials(
-	    advancedbilling.NewBasicAuthCredentials(
-        cfg.APIKey,
-        cfg.Password,
-      ),
-	  ),
+		advancedbilling.WithBasicAuthCredentials(
+			advancedbilling.NewBasicAuthCredentials(
+				cfg.APIKey,
+				cfg.Password,
+			),
+		),
 		advancedbilling.WithDomain(cfg.Domain),
 		advancedbilling.WithSubdomain(cfg.Subdomain),
 	)
 
 	configUnauthorized := advancedbilling.CreateConfiguration(
-    advancedbilling.WithBasicAuthCredentials(
-          advancedbilling.NewBasicAuthCredentials(
-            "abc",
-            "abc",
-          ),
-        ),
+		advancedbilling.WithBasicAuthCredentials(
+			advancedbilling.NewBasicAuthCredentials(
+				"abc",
+				"abc",
+			),
+		),
 		advancedbilling.WithDomain(cfg.Domain),
 		advancedbilling.WithSubdomain(cfg.Subdomain),
 	)
@@ -153,22 +153,22 @@ func (s *APISuite) generateProduct(ctx context.Context, productFamilyID int) mod
 }
 
 func (s *APISuite) generateCoupon(ctx context.Context, productFamilyID int) models.Coupon {
-	coupon := &models.Coupon{
-		Name:                        strPtr(s.fkr.RandomStringWithLength(20)),
-		Code:                        strPtr("100OFF" + s.fkr.RandomStringWithLength(30)),
+	coupon := &models.CreateOrUpdatePercentageCoupon{
+		Name:                        s.fkr.RandomStringWithLength(20),
+		Code:                        "100OFF" + s.fkr.RandomStringWithLength(30),
 		Description:                 strPtr(s.fkr.RandomStringWithLength(20)),
-		Percentage:                  models.NewOptional[string](strPtr("50")),
+		Percentage:                  models.CreateOrUpdatePercentageCouponPercentageContainer.FromString("50"),
 		AllowNegativeBalance:        boolPtr(false),
 		Recurring:                   boolPtr(false),
-		EndDate:                     models.NewOptional(timePtr(time.Now().AddDate(1, 0, 0))),
-		ProductFamilyId:             &productFamilyID,
+		EndDate:                     timePtr(time.Now().AddDate(1, 0, 0)),
+		ProductFamilyId:             models.ToPointer(fmt.Sprint(productFamilyID)),
 		Stackable:                   boolPtr(false),
 		ExcludeMidPeriodAllocations: boolPtr(true),
 		ApplyOnCancelAtEndOfPeriod:  boolPtr(true),
 	}
 
 	resp, err := s.client.CouponsController().CreateCoupon(ctx, productFamilyID, &models.CreateOrUpdateCoupon{
-		Coupon: interfacePtr(coupon),
+		Coupon: models.ToPointer(models.CreateOrUpdateCouponCouponContainer.FromCreateOrUpdatePercentageCoupon(*coupon)),
 	})
 
 	s.NoError(err)
@@ -189,8 +189,8 @@ func (s *APISuite) generateMeteredComponent(ctx context.Context, productFamilyID
 				PricingScheme: models.PricingScheme_STAIRSTEP,
 				Prices: []models.Price{
 					{
-						StartingQuantity: 1,
-						UnitPrice:        1,
+						StartingQuantity: models.PriceStartingQuantityContainer.FromNumber(1),
+						UnitPrice:        models.PriceUnitPriceContainer.FromPrecision(1),
 					},
 				},
 			},
@@ -226,8 +226,8 @@ func (s *APISuite) generateSubscription(
 					LastName:        &s.baseBillingAddress.lastName,
 					FullNumber:      &s.baseBillingAddress.phone,
 					CardType:        toPtr[models.CardType](models.CardType_VISA),
-					ExpirationMonth: interfacePtr(1),
-					ExpirationYear:  interfacePtr(time.Now().Year() + 1),
+					ExpirationMonth: models.ToPointer(models.PaymentProfileAttributesExpirationMonthContainer.FromNumber(1)),
+					ExpirationYear:  models.ToPointer(models.PaymentProfileAttributesExpirationYearContainer.FromNumber(time.Now().Year() + 1)),
 					BillingAddress:  &s.baseBillingAddress.address,
 					BillingCity:     &s.baseBillingAddress.city,
 					BillingState:    &s.baseBillingAddress.state,


### PR DESCRIPTION
## Notes:
- Do not merge these tests before generating the latest go sdk
- These changes are adding the breaking changes to the existing unit-tests that we have introduced in the latest release
- We have also added the `payment_profiles_test.go` flow by following a use case from Java's flow: [PaymentProfileCreate](https://github.com/maxio-com/ab-java-sdk/blob/main/tests/src/test/java/com/maxio/advancedbilling/controllers/paymentprofiles/PaymentProfilesControllerCreateTest.java)